### PR TITLE
Reset password refers users to localhost in production environments [fix]

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ MONGO_URI=mongodb://localhost:27017/nodeapi
 PORT=8080
 JWT_SECRET=xxxxxx
 CLIENT_URL=http://localhost:3000
+RESET_PASSWORD=://[enter_public_ip_for_production]
 REACT_APP_GOOGLE_CLIENT_ID=xxxxxx.apps.googleusercontent.com
 ```
 

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -73,6 +73,8 @@ exports.forgotPassword = (req, res) => {
         const token = jwt.sign({ _id: user._id, iss: process.env.APP_NAME }, process.env.JWT_SECRET);
 
         // email data
+        // Change RESET_PASSWORD to CLIENT_URL if you are in a Development Environment, as
+        // RESET_PASSWORD is only used in production environments
         const emailData = {
             from: 'noreply@node-react.com',
             to: email,

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -78,10 +78,10 @@ exports.forgotPassword = (req, res) => {
             to: email,
             subject: 'Password Reset Instructions',
             text: `Please use the following link to reset your password: ${
-                process.env.CLIENT_URL
+                process.env.RESET_PASSWORD
             }/reset-password/${token}`,
             html: `<p>Please use the following link to reset your password:</p> <p>${
-                process.env.CLIENT_URL
+                process.env.RESET_PASSWORD
             }/reset-password/${token}</p>`
         };
 


### PR DESCRIPTION
I have added the new reference to redirect users to the correct path.

it will require the user to add an additional line to their env file called RESET_PASSWORD